### PR TITLE
Add simple TestFX that test the first two screens and update onPlayerConfigClick to appropriately handle no selection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                    <argLine>--add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/main/java/com/draobemag/mariokart/Controllers/ConfigController.java
+++ b/src/main/java/com/draobemag/mariokart/Controllers/ConfigController.java
@@ -32,10 +32,16 @@ public class ConfigController
     protected void onPlayerConfigClick(ActionEvent event) throws IOException
     {
         RadioButton toggleButton= (RadioButton) group.getSelectedToggle();
-        String value = toggleButton.getText();
-        numOfDrivers = Integer.parseInt(value);
-
-        GameManager.SetNumPlayers(numOfDrivers);
-        GameManager.GameManager().stage.setScene(SceneType.LoadScene(SceneType.PLAYER));
+        if (toggleButton == null) {
+            Alert alert = new Alert(Alert.AlertType.ERROR);
+            alert.setHeaderText("ERROR");
+            alert.setContentText("Please select a number of drivers before proceeding!");
+            alert.showAndWait();
+        } else {
+            String value = toggleButton.getText();
+            numOfDrivers = Integer.parseInt(value);
+            GameManager.SetNumPlayers(numOfDrivers);
+            GameManager.GameManager().stage.setScene(SceneType.LoadScene(SceneType.PLAYER));
+        }
     }
 }

--- a/src/test/java/GameScreensTest.java
+++ b/src/test/java/GameScreensTest.java
@@ -1,0 +1,52 @@
+import com.draobemag.mariokart.HelloApplication;
+
+
+import org.junit.Test;
+
+import javafx.stage.Stage;
+import javafx.scene.Node;
+import javafx.scene.text.Text;
+
+import org.testfx.framework.junit.ApplicationTest;
+import org.testfx.matcher.base.NodeMatchers;
+
+import static org.junit.Assert.assertNotNull;
+import static org.testfx.api.FxAssert.verifyThat;
+
+
+
+
+public class GameScreensTest extends ApplicationTest {
+    private  Stage myStage;
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        HelloApplication helloApplication = new HelloApplication();
+        helloApplication.start(primaryStage);
+        myStage = primaryStage;
+    }
+
+    @Test
+    public void testWelcomeScreenLaunched() {
+        // Ensure the 'Start Your Engines!' button is present
+        verifyThat("Start Your Engines!", NodeMatchers.isVisible());
+    }
+
+    @Test
+    public void testNextScreen() {
+        clickOn("#initStart");
+        // Check that we progressed to the next screen by ensuring the 'Go!' button is present
+        verifyThat("Go!", NodeMatchers.isVisible());
+    }
+
+    @Test
+    public void testNumDriversAlert() {
+        // Advance to next screen
+        clickOn("#initStart");
+        // Alert should occur since the number of drivers was not selected
+        clickOn("#playerConfig");
+        // Get the Node of the Alert
+        Node alertNode = lookup(".dialog-pane").query();
+        assertNotNull(alertNode);
+    }
+}


### PR DESCRIPTION
Got TestFX working and added a couple hacky/simple tests. Should be simple enough to extend the work in this commit to any other GUI tests we want to write 🙂